### PR TITLE
Specify axis in pd.concat as kwarg

### DIFF
--- a/commodutil/stats.py
+++ b/commodutil/stats.py
@@ -33,6 +33,6 @@ def reindex_zscore(df, range=10):
         z = (d.mean(axis=1) - df.loc[:, year]) / d.std(axis=1)
         z.name = year
         dfs.append(z)
-    res = pd.concat(dfs, 1)
+    res = pd.concat(dfs, axis=1)
 
     return res


### PR DESCRIPTION
Fixes following pandas warning:
```
commodutil\stats.py:36: FutureWarning: In a future version of pandas all arguments of concat except for the argument 'objs' will be keyword-only
  res = pd.concat(dfs, 1)
```